### PR TITLE
Add docs about front end, dependencies, branches

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -114,7 +114,19 @@ def set_standalone():
     g.standalone = True
 ```
 
-### Outstanding questsion
+### Third Party Libraries
+
+JS and CSS third party libraries loaded by the LibreHQ app should be served
+from our servers, rather than from elsewhere like a CDN (Content Delivery
+Network). The versions of these libraries that we use should be committed
+and tracked by git. The reasons for this include consistency and security.
+
+For minified versions of these libraries (i.e. bulma.css and bulma.min.css),
+both versions should be present in the repo and also on our servers, so that
+anyone can just remove the 'min' from the URL to see the non-minified
+source code.
+
+### Outstanding questions
 
 Some outstanding questions to be determined via development:
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -89,6 +89,9 @@ through partials and flask blueprints.  Some conventions:
 
 ### Templates
 
+_Note: this section will need to be updated once templates are moved to
+Vue.js, see 'Front End' section below._
+
 When designing module pages, all of the templates should be in the
 `templates/<modulename>/` subdirectory to prevent confusion in the top
 level directory.  For instance, if you have `templates/dashboard.html`,
@@ -126,6 +129,28 @@ both versions should be present in the repo and also on our servers, so that
 anyone can just remove the 'min' from the URL to see the non-minified
 source code.
 
+### Front End
+
+[Vue.js](https://vuejs.org/) will be used on the front end for HTML
+templating and for working with the DOM. (The current Flask/Jinja
+templates will be moved to Vue templates/components.) The Flask server
+will send JSON data to be rendered into pages by Vue. One advantage of
+this decoupled approach is it is easier to test the server in isolation
+from the client, and vice-versa (by using mock JSON data). Further details
+are TBD but one possibility would be to take a
+['single-page-app'](https://en.wikipedia.org/wiki/Single-page_application)
+approach.
+
+The submodule services that LibreHQ provides (wiki, chat, etc.) will be
+separate from the main LibreHQ (Vue-based) UI. There won't be a Vue wrapper
+page that loads a wiki in an iframe or anything like that. There will be UI
+for managing a wiki in the LibreHQ app, but when you open the wiki it will
+look like a regular vanilla wiki, and there won't be anything Vue-rendered
+on the page, no LibreHQ header, footer, etc.
+
+LibreHQ will use [npm](https://www.npmjs.com/) to manage Vue and other
+front-end dependencies.
+
 ### Outstanding questions
 
 Some outstanding questions to be determined via development:
@@ -135,3 +160,8 @@ Some outstanding questions to be determined via development:
   design?
 * What level of functionality should be exposed in the main dashboard
   through `main_partial`
+* Currently submodules provide the UI/templates for their management,
+  which are displayed within the main dashboard. Will they still do this
+  when templating is moved to Vue.js? How? Would each submodule provide a
+  Vue component that's rendered in the main dashboard? This would mean
+  each submodule would have its own npm-managed front-end dependencies?

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -151,6 +151,23 @@ on the page, no LibreHQ header, footer, etc.
 LibreHQ will use [npm](https://www.npmjs.com/) to manage Vue and other
 front-end dependencies.
 
+### Git Branches
+
+In addition to short-lived 'feature' branches where work on particular
+issues is done, there will be several long-lived git branches for
+various purposes. Basically changes will work their way from the top of
+this list to the bottom.
+
+- __mvp-dev__ (currently named __mvp__): Contains work on the initial
+'minimum viable product'. Feature branches are merged into this branch
+during initial mvp phase. Will not be needed after mvp phase is done.
+- __master__: Has the latest code that has been tested and reviewed.
+(Changes are reviewed via PR before landing on master.)
+- __testing__ and/or __demo__: Code that is loaded on testing and/or
+demo servers. May have changes/features that aren't in production yet.
+- __production__: The stable code that is 'officially released' for use
+in production installations/servers.
+
 ### Outstanding questions
 
 Some outstanding questions to be determined via development:


### PR DESCRIPTION
These doc additions come out of a phone meeting with @kfogel , @frankduncan and myself, on November 20th:
- document practice of committing 3rd party libraries, and serving them from our servers
- document decisions about front end stack, using Vue, and what this means for structure of the app, server/client, mocks, testing, etc.
- document branches that we'll use (production, tesing/demo, master, mvp-dev)

I just put them the DESIGN.md file for now.  Let me know if another/new file would be better.