### PR TITLE
Edit docs to reflect removal of git submodules

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,98 @@
+# Project Code of Conduct
+
+This project is a community of professionals who work better when we
+all treat each other with respect.  This document describes the
+standards to which we aspire.
+
+Participants in this project community are considerate of each other.
+We are open to collaboration and receptive to constructive comment and
+criticism.  We strive to welcome those who wish to contribute to our
+efforts.
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers try to stay attentive in our
+communications, and to be tactful and courteous when broaching
+divergent or controversial views.
+
+We require participants in our project and our community to maintain
+high standards for rejecting harassment and discrimination,
+particularly with regard to age, body size, disability, ethnicity,
+gender identity and expression, level of experience, employment,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+Examples of behavior that contribute to creating a positive
+environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Acting with empathy for other community members
+
+Examples of behavior that harms our efforts to create a positive
+environment include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Harassment, whether in public or in private
+* Publishing others' private information, such as real name, or
+  physical or electronic address, without permission
+* Other behavior that would be inappropriate in a professional setting
+
+## Our Responsibilities
+
+We all share a responsibility to create an environment that encourages
+behavior that meets these standards.  In addition, the
+project maintainers (those who have direct push access to the repository)
+are responsible for clarifying the standards of acceptable behavior
+and are expected to take appropriate and fair corrective action in
+response to instances of unacceptable behavior.  Their own behavior
+should be held to high standards.
+
+Project maintainers have the right and responsibility to enforce this
+Code of Conduct.  This might include removing, editing, or rejecting
+contributions that do not meet standards.  It might also involve
+suspending or banning participants who do not behave appropriately.
+
+## Scope
+
+We expect people to maintain these standards both within project
+spaces and at events where they are representing the project or its
+community. Examples of representing a project or community include
+using an official project e-mail address, posting via project social
+media accounts, or acting as an appointed representative at an event.
+
+## Meeting Our Responsibilities
+
+Contributors are welcome and encouraged to resolve conflicts directly
+with each other, when they feel comfortable doing so.
+
+If issues can not be resolved directly among affected people, they should
+report instances of abusive, harassing, or otherwise unacceptable
+behavior to the Code of Conduct (CoC) team.
+
+_TODO: Issue #10: assemble a CoC team, then list who is on the team
+and add an email address for contacting them here._
+
+Contributors are also welcome and encouraged to contact the CoC team
+to ask for advice on speaking with another contributor to resolve a
+conflict directly.
+
+The team will review reports, make inquiries and respond as best
+it can.  The individuals on the CoC team will maintain reasonable
+confidentiality about confidential matters like the identity of
+incident reporters, the reported participants in incidents, and the
+details of reports.  At the same time, the team might discuss
+publicly-known or non-confidential matters with the community,
+especially when an incident affects a wider audience.
+
+## Attribution
+
+This Code of Conduct is heavily adapted from the
+[Contributor Covenant][homepage], version 1.4, available at
+[http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,9 @@ demo servers. May have changes/features that aren't in production yet.
 - __production__: The stable code that is 'officially released' for use
 in production installations/servers.
 
+## Third Party Libraries
+
+JS and CSS third party libraries loaded by the LibreHQ app should be served
+from our servers, rather than from elsewhere like a CDN (Content Delivery
+Network). The versions of these libraries that we use should be committed
+and tracked by git. The reasons for this include consistency and security.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# CONTRIBUTING
+
+## Git Branches
+
+In addition to short-lived 'feature' branches where work on particular
+issues is done, there will be several long-lived git branches for
+various purposes. Basically changes will work their way from the top of
+this list to the bottom.
+
+- __mvp-dev__: Contains work in progress on the initial 'minimum viable
+product'. Feature branches are merged into this branch during this
+initial mvp phase. In this early phase, the level of review for merging
+code into this branch need not be as high as for merging to master.
+This branch will go away after the mvp phase.
+- __master__: All feature branches merged into master are tested and
+reviewed via pull requests on github before being merged in.
+- __testing__ and/or __demo__: Code that is loaded on testing and/or
+demo servers. May have changes/features that aren't in production yet.
+- __production__: The stable code that is 'officially released' for use
+in production installations/servers.
+

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,6 +38,15 @@ to approve the transfer.
 
 ## Services and URLs
 
+For clear communication, we'll specify some terminology for services
+and their sub-parts.  A given 'service' includes both an 'upstream
+package' (e.g. MediaWiki), and a 'service wrapper', which is our
+LibreHQ code for managing and working with the 'upstream package'.
+
+Service wrapper code is written in Python (and JavaScript for
+UI/front end), regardless of the language of the upstream package
+(e.g. PHP).
+
 To create an account, start at `https://librehq.com/`.  Afterwards
 you'll have a landing page at `https://librehq.com/USER` that lists
 all the services available and which ones are active (remember, in the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -77,24 +77,13 @@ forward from the old username for up to some predetermined amount of
 time -- but at least we can set things up so that this is a policy
 decision rather than a technical constraint.
 
-## Modules
+## Service Modules
 
-Each LibreHQ service gets its own repository, in order to keep the
-development lifecycle of each codebase separate.  They are imported
-into LibreHQ-core via git submodules, and expose their functionality
-through partials and flask blueprints.  Some conventions:
+Each LibreHQ service is a Python module in its own directory. Some
+conventions:
 
-* The repository name is `librehq-<service>`, with the directory for
-  the git submodule to be just `<service>`
-* Only merge submodule sha changes to librehq-core when stable, and
-  collapse so that only one sha update is done
-* Submodule sha updates should live in their own commits
-* The service should be bootable on its own, via flask
-* The service should expose a `from service import bp` which represents
-  the Blueprint for that submodule
-* The Blueprint should use as a base `"/<service>/"` for web requets
-* The service should expose a `main_partial()` that returns a template
-  to be imported into the main section
+* The directory for the service will be just `<service>` (e.g. 'wikis')
+* The service should use as a base `"/<service>/"` for web requests
 
 ### Templates
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -102,12 +102,7 @@ Some outstanding questions to be determined via development:
   service they provide, or should they adhere to a greater librehq
   design?
 * What level of functionality should be exposed in the main dashboard
-  through `main_partial`
-* Currently submodules provide the UI/templates for their management,
-  which are displayed within the main dashboard. Will they still do this
-  when templating is moved to Vue.js? How? Would each submodule provide a
-  Vue component that's rendered in the main dashboard? This would mean
-  each submodule would have its own npm-managed front-end dependencies?
+  for each service?
 
 ## Front End
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -117,18 +117,6 @@ def set_standalone():
     g.standalone = True
 ```
 
-### Third Party Libraries
-
-JS and CSS third party libraries loaded by the LibreHQ app should be served
-from our servers, rather than from elsewhere like a CDN (Content Delivery
-Network). The versions of these libraries that we use should be committed
-and tracked by git. The reasons for this include consistency and security.
-
-For minified versions of these libraries (i.e. bulma.css and bulma.min.css),
-both versions should be present in the repo and also on our servers, so that
-anyone can just remove the 'min' from the URL to see the non-minified
-source code.
-
 ### Front End
 
 [Vue.js](https://vuejs.org/) will be used on the front end for HTML

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -85,57 +85,14 @@ conventions:
 * The directory for the service will be just `<service>` (e.g. 'wikis')
 * The service should use as a base `"/<service>/"` for web requests
 
-### Templates
+### Service Templates
 
-_Note: this section will need to be updated once templates are moved to
-Vue.js, see 'Front End' section below._
-
-When designing module pages, all of the templates should be in the
-`templates/<modulename>/` subdirectory to prevent confusion in the top
-level directory.  For instance, if you have `templates/dashboard.html`,
-in your module, when running as part of the larger librehq site, the main
-core `templates/dashboard.html` will get chosen for rendering, even if
-called from the module Blueprint.  So, you need to have (for example)
-`templates/wikis/dashboard.html` and reference `wikis/dashboard.html` in
-your modules flask code.
-
-Similarly, you should include the line:
-
-```
-{% if not g.standalone %}{% extends "base.html" %}{% endif %}
-```
-
-in all of your templates to pull in the header/footer from the core package
-when not running as a standalone app.  Then, in your standalone bootup
-section (usually in `__init__.py`), you should have the following:
-
-```python
-@app.before_request
-def set_standalone():
-    g.standalone = True
-```
-
-### Front End
-
-[Vue.js](https://vuejs.org/) will be used on the front end for HTML
-templating and for working with the DOM. (The current Flask/Jinja
-templates will be moved to Vue templates/components.) The Flask server
-will send JSON data to be rendered into pages by Vue. One advantage of
-this decoupled approach is it is easier to test the server in isolation
-from the client, and vice-versa (by using mock JSON data). Further details
-are TBD but one possibility would be to take a
-['single-page-app'](https://en.wikipedia.org/wiki/Single-page_application)
-approach.
-
-The submodule services that LibreHQ provides (wiki, chat, etc.) will be
-separate from the main LibreHQ (Vue-based) UI. There won't be a Vue wrapper
-page that loads a wiki in an iframe or anything like that. There will be UI
-for managing a wiki in the LibreHQ app, but when you open the wiki it will
-look like a regular vanilla wiki, and there won't be anything Vue-rendered
-on the page, no LibreHQ header, footer, etc.
-
-LibreHQ will use [npm](https://www.npmjs.com/) to manage Vue and other
-front-end dependencies.
+The template files for a service that are served by Flask are generated
+by the Vue.js front end compile step. For example, a `wikis.html` file
+is generated in `librehq/templates` where Flask looks for it. These
+files are served by Flask as-is, without any data added to them, so
+they're not really functioning as templates.  Rather, data is fetched
+by a separate request to the server and added to the page by Vue.js.
 
 ### Outstanding questions
 
@@ -151,3 +108,24 @@ Some outstanding questions to be determined via development:
   when templating is moved to Vue.js? How? Would each submodule provide a
   Vue component that's rendered in the main dashboard? This would mean
   each submodule would have its own npm-managed front-end dependencies?
+
+## Front End
+
+[Vue.js](https://vuejs.org/) will be used on the front end for HTML
+templating and for working with the DOM.  The Flask server will send
+JSON data to be rendered into pages by Vue. One advantage of
+this decoupled approach is it is easier to test the server in isolation
+from the client, and vice-versa (by using mock JSON data). Further details
+are TBD but one possibility would be to take a
+['single-page-app'](https://en.wikipedia.org/wiki/Single-page_application)
+approach.
+
+From a user's perspective, the services that LibreHQ provides (wiki, chat,
+etc.) will generally be separate from the LibreHQ UI. E.g. there will be a
+LibreHQ UI for managing a wiki in the LibreHQ app, but when you visit the
+wiki it will look like a regular vanilla wiki, and there won't be anything
+Vue-rendered on the wiki pages, no LibreHQ header, footer, etc.
+
+LibreHQ will use [npm](https://www.npmjs.com/) to manage Vue and other
+front-end dependencies.
+

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -151,23 +151,6 @@ on the page, no LibreHQ header, footer, etc.
 LibreHQ will use [npm](https://www.npmjs.com/) to manage Vue and other
 front-end dependencies.
 
-### Git Branches
-
-In addition to short-lived 'feature' branches where work on particular
-issues is done, there will be several long-lived git branches for
-various purposes. Basically changes will work their way from the top of
-this list to the bottom.
-
-- __mvp-dev__: Contains work on the initial
-'minimum viable product'. Feature branches are merged into this branch
-during initial mvp phase. Will not be needed after mvp phase is done.
-- __master__: Has the latest code that has been tested and reviewed.
-(Changes are reviewed via PR before landing on master.)
-- __testing__ and/or __demo__: Code that is loaded on testing and/or
-demo servers. May have changes/features that aren't in production yet.
-- __production__: The stable code that is 'officially released' for use
-in production installations/servers.
-
 ### Outstanding questions
 
 Some outstanding questions to be determined via development:


### PR DESCRIPTION
- Edit DESIGN.md to reflect removal of git submodules.
- Start a CONTRIBUTING.md and move some content from DESIGN.md there.  
- Add a CODE_OF_CONDUCT.md

These changes are on top of those in PR #9, and should be merged after PR #9 is merged.  A separate PR to make review simpler.  These are the commits to make it easier to review the changes before #9 is merged.

Move branches docs to new CONTRIBUTING.md file
Move docs about libraries to CONTRIBUTING.md
Add services terminology to DESIGN.md
Edit 'Modules' in DESIGN.md (no git submodules)
Revise 'Front End' and 'Templates' in DESIGN.md
Revise 'Outstanding Questions' in DESIGN.md
Add Code of Conduct document